### PR TITLE
Fix prompt bundling to ensure all prompts are properly included in the package

### DIFF
--- a/src/__tests__/bundledPrompts.test.ts
+++ b/src/__tests__/bundledPrompts.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Tests for bundled prompts
+ * 
+ * This file contains tests to verify that bundled prompts are properly
+ * loaded and used by the system.
+ */
+
+import { getBundledPrompt } from '../prompts/bundledPrompts';
+import { PromptManager } from '../prompts/PromptManager';
+import { ReviewType } from '../types/review';
+
+describe('bundledPrompts', () => {
+  describe('getBundledPrompt', () => {
+    it('should return a prompt for each review type', () => {
+      const reviewTypes: ReviewType[] = [
+        'quick-fixes',
+        'architectural',
+        'security',
+        'performance',
+        'unused-code'
+      ];
+
+      // Check that each review type has a bundled prompt
+      for (const reviewType of reviewTypes) {
+        const prompt = getBundledPrompt(reviewType);
+        expect(prompt).toBeDefined();
+        expect(typeof prompt).toBe('string');
+        expect(prompt.length).toBeGreaterThan(100); // Ensure it's a substantial prompt
+      }
+    });
+
+    it('should return language-specific prompts when available', () => {
+      // Test TypeScript-specific architectural prompt
+      const tsPrompt = getBundledPrompt('architectural', 'typescript');
+      expect(tsPrompt).toBeDefined();
+      expect(tsPrompt).toContain('TypeScript Architectural Code Review');
+
+      // Test generic architectural prompt
+      const genericPrompt = getBundledPrompt('architectural');
+      expect(genericPrompt).toBeDefined();
+      expect(genericPrompt).toContain('Architectural Code Review');
+      
+      // They should be different
+      expect(tsPrompt).not.toBe(genericPrompt);
+    });
+
+    it('should fall back to generic prompts when language-specific ones are not available', () => {
+      // Test a language that doesn't have specific prompts
+      const pythonPrompt = getBundledPrompt('quick-fixes', 'python');
+      const genericPrompt = getBundledPrompt('quick-fixes');
+      
+      expect(pythonPrompt).toBeDefined();
+      expect(genericPrompt).toBeDefined();
+      expect(pythonPrompt).toBe(genericPrompt);
+    });
+  });
+
+  describe('PromptManager integration', () => {
+    it('should prioritize bundled prompts', async () => {
+      const promptManager = PromptManager.getInstance();
+      
+      // Get a prompt template for a review type that has a bundled prompt
+      const prompt = await promptManager.getPromptTemplate('quick-fixes');
+      
+      // Verify it's the bundled prompt
+      expect(prompt).toBeDefined();
+      expect(prompt).toContain('Quick Fixes Code Review');
+    });
+
+    it('should handle placeholders in bundled prompts', async () => {
+      const promptManager = PromptManager.getInstance();
+      
+      // Get a prompt template with language option
+      const prompt = await promptManager.getPromptTemplate('quick-fixes', {
+        language: 'javascript',
+        type: 'quick-fixes'
+      });
+      
+      // Verify language placeholder was replaced
+      expect(prompt).toBeDefined();
+      expect(prompt).toContain('This code is written in JAVASCRIPT');
+    });
+  });
+});

--- a/src/clients/utils/promptLoader.ts
+++ b/src/clients/utils/promptLoader.ts
@@ -1,20 +1,31 @@
 /**
  * @fileoverview Utilities for loading prompt templates.
  *
- * This module provides functions for loading prompt templates from the file system,
- * supporting language-specific templates and fallbacks to default templates.
+ * IMPORTANT: This module provides functions for loading prompt templates from BUNDLED PROMPTS ONLY.
+ * The system prioritizes bundled prompts and only falls back to file system prompts if a bundled prompt is not found.
  *
- * This is a compatibility layer that uses the new PromptManager internally.
+ * All core prompts are defined in the bundledPrompts.ts file and accessed through the PromptManager.
+ * This ensures that the system always has access to the prompts it needs, regardless of
+ * where it's installed or how it's packaged.
+ *
+ * This module is a compatibility layer that uses the PromptManager internally.
  */
 
 import { ReviewType, ReviewOptions } from '../../types/review';
 import { PromptManager } from '../../prompts/PromptManager';
 
 /**
- * Load a prompt template from the prompts directory
+ * Load a prompt template
  * @param reviewType Type of review to perform
  * @param options Review options including language
  * @returns Promise resolving to the prompt template
+ *
+ * IMPORTANT: This function prioritizes bundled prompts.
+ * The system will first try to use bundled prompts defined in bundledPrompts.ts.
+ * Only if a bundled prompt is not found will it fall back to custom templates.
+ *
+ * This ensures that the system always has access to the prompts it needs,
+ * regardless of where it's installed or how it's packaged.
  */
 export async function loadPromptTemplate(
   reviewType: ReviewType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 
 /**
  * @fileoverview Main entry point for the AI Code Review CLI tool.
@@ -74,7 +73,7 @@ let toolDirectory = '';
 for (const dir of possibleToolDirectories) {
   const envPath = path.resolve(dir, '.env.local');
   debugLog(`Checking for tool .env.local in: ${envPath}`);
-  
+
   try {
     if (fs.existsSync(envPath)) {
       toolEnvPath = envPath;
@@ -116,7 +115,7 @@ if (toolEnvPath) {
   // If not found in any tool directory, fall back to current working directory
   console.log('No .env.local found in tool directory. Looking in current directory...');
   const envLocalPath = path.resolve(process.cwd(), '.env.local');
-  
+
   try {
     const cwdEnvExists = fs.existsSync(envLocalPath);
     if (cwdEnvExists) {
@@ -158,14 +157,14 @@ import { listModelConfigs } from './clients/utils/modelLister';
 
 // Hardcoded version number to ensure --version flag works correctly
 // This is more reliable than requiring package.json which can be affected by npm installation issues
-const VERSION = '2.1.3';
+const VERSION = '2.1.5';
 
 // Main function to run the application
 async function main() {
   try {
     // Always display version at startup
     logger.info(`AI Code Review Tool v${VERSION}`);
-    
+
     // Parse command-line arguments
     const args = await getCommandLineArguments();
 
@@ -189,19 +188,19 @@ async function main() {
       console.log("\n=== API Key Required ===");
       console.log("No API keys were found in environment variables or command-line arguments.");
       console.log("\nTo provide an API key, you can:");
-      
+
       console.log("\n1. Create a .env.local file with one of these entries:");
       console.log("   - AI_CODE_REVIEW_GOOGLE_API_KEY=your_google_api_key_here");
       console.log("   - AI_CODE_REVIEW_OPENROUTER_API_KEY=your_openrouter_api_key_here");
       console.log("   - AI_CODE_REVIEW_ANTHROPIC_API_KEY=your_anthropic_api_key_here");
       console.log("   - AI_CODE_REVIEW_OPENAI_API_KEY=your_openai_api_key_here");
-      
+
       console.log("\n2. Or specify an API key via command-line flag:");
       console.log("   - --google-api-key=your_google_api_key_here");
       console.log("   - --openrouter-api-key=your_openrouter_api_key_here");
       console.log("   - --anthropic-api-key=your_anthropic_api_key_here");
       console.log("   - --openai-api-key=your_openai_api_key_here");
-      
+
       console.log("\n3. Or set an environment variable in your shell:");
       console.log("   export AI_CODE_REVIEW_OPENAI_API_KEY=your_openai_api_key_here\n");
       process.exit(1);
@@ -265,10 +264,14 @@ async function main() {
       });
     }
 
-    // Load prompt templates
+    // Initialize the prompt manager
     const promptManager = PromptManager.getInstance();
 
-    // First try to load templates from the current directory
+    // Log that we're using bundled prompts
+    logger.info("Using bundled prompts as the primary source for templates");
+
+    // Optionally load custom templates from the current directory
+    // These are only used as fallbacks if bundled prompts are not available
     const localTemplatesDir = path.resolve(
       process.cwd(),
       'prompts',
@@ -276,14 +279,10 @@ async function main() {
     );
     await promptManager.loadTemplates(localTemplatesDir);
 
-    // Then try to load templates from the package directory
-    const packageTemplatesDir = path.resolve(__dirname, 'prompts', 'templates');
-    await promptManager.loadTemplates(packageTemplatesDir);
-
-    // Log the loaded templates
+    // Log the loaded custom templates
     const templates = promptManager.listTemplates();
     if (templates.length > 0) {
-      logger.info(`Loaded ${templates.length} prompt templates:`);
+      logger.info(`Loaded ${templates.length} custom prompt templates:`);
       templates.forEach(template => {
         logger.info(
           `- ${template.name}: ${template.description} (${template.reviewType})`


### PR DESCRIPTION
## Description

This PR fixes issue #10 by ensuring that prompt bundling works correctly. The system now properly prioritizes bundled prompts and only falls back to file system prompts if a bundled prompt is not found.

## Changes Made

1. Updated `PromptManager.ts` to:
   - Clearly document that bundled prompts are the primary source
   - Modify the `loadTemplates` method to make it clear it's only for custom templates
   - Update the `getPromptTemplate` method to prioritize bundled prompts

2. Updated `index.ts` to:
   - Remove unnecessary calls to load prompts from the package directory
   - Add clear logging about using bundled prompts

3. Updated `promptLoader.ts` to:
   - Clarify that it prioritizes bundled prompts
   - Update documentation to reflect the new prompt loading strategy

4. Added tests in `bundledPrompts.test.ts` to verify that:
   - Bundled prompts are properly loaded
   - Language-specific prompts are used when available
   - The system falls back to generic prompts when needed
   - The PromptManager correctly prioritizes bundled prompts

## Testing

- Added new tests specifically for bundled prompts
- All tests pass

## Related Issues

Fixes #10

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author