### PR TITLE
🐛 Fix Gemini reviews returning JSON instead of Markdown format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.9] - 2025-05-05
+
+### Fixed
+- Fixed critical bug in global CLI installation where the executable was missing the shebang line
+- Modified build process to ensure shebang line is always included in the bundled output
+- Improved global installation reliability across different environments
+
+## [2.1.8] - 2025-05-03
+
+### Fixed
+- Fixed minor issues with model validation during builds
+- Enhanced error reporting for missing API keys
+
 ## [2.1.7] - 2025-05-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.10] - 2025-05-05
+
+### Fixed
+- Fixed issue where Gemini reviews were returning JSON format instead of Markdown
+- Modified the prompt instructions in GeminiClient to explicitly request Markdown output
+- Ensured consistent output format across all model providers (Gemini, Anthropic, OpenAI)
+
 ## [2.1.9] - 2025-05-05
 
 ### Fixed

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,21 +1,6 @@
 # 🔧 INSTRUCTIONS (GitHub-Centric Workflow)
 
-Updated: 2025-05-04
-
-## 📋 Table of Contents
-
-- [1. Agent Protocol & Execution Flow](#-1-agent-protocol--execution-flow)
-- [2. Core Principles](#-2-core-principles)
-- [3. Stack-Specific Directives](#-3-stack-specific-directives)
-- [4. Monorepo Workflow](#-4-monorepo-workflow)
-- [5. Best Practices](#-5-best-practices)
-- [6. Testing Standards](#-6-testing-standards)
-- [7. CI / DevOps](#-7-ci--devops)
-- [8. Documentation](#-8-documentation)
-- [9. Code Quality & Workflow](#-9-code-quality--workflow)
-- [10. Git Workflow & Version Control](#-10-git-workflow--version-control)
-- [11. GitHub Issue Tracking](#-11-github-issue-tracking)
-- [12. AI Assistant Guidelines](#-12-ai-assistant-guidelines)
+Updated: 5-05-2025
 
 ---
 
@@ -107,52 +92,21 @@ Updated: 2025-05-04
 * `pnpm lint && pnpm typecheck && pnpm test` required before merge.
 * Feature branches only. Use squash merges.
 
-### Common Commands
-
-```bash
-# Install dependencies
-pnpm install
-
-# Run linting
-pnpm lint
-
-# Run type checks
-pnpm typecheck
-
-# Run tests
-pnpm test
-
-# Run build
-pnpm build
-```
-
 ---
 
 ## ✅ 5. Best Practices
 
-### Modern Standards
-
 * Use modern, community-validated standards.
 * Prefer mature, well-supported libraries.
 * Explain any deviations from best practices.
-
-### Simplicity and Elegance
-
-* Prioritize clarity over cleverness.
-* Favor minimal, working implementations.
-* Confirm with users when there's a risk of over-engineering.
-
-### Confirmation & Safety
-
 * Confirm before changing behavior, logic, or architecture.
-* Validate assumptions before introducing new patterns.
 
 ---
 
 ## 🧪 6. Testing Standards
 
 * All utilities and APIs must have unit tests.
-* Use **[Vitest](https://vitest.dev/)** (`pnpm test`).
+* Use **Vitest** (`pnpm test`).
 * Minimum 80% coverage unless annotated with `@low-test-priority`.
 * Avoid snapshots unless explicitly justified.
 * Prefer real API interactions over mocks.
@@ -161,11 +115,7 @@ pnpm build
 
 ## ⚙️ 7. CI / DevOps
 
-* Pre-commit hooks must run:
-
-  * Linting (`pnpm lint`)
-  * Type-checking (`pnpm typecheck`)
-  * Tests (`pnpm test`)
+* Pre-commit hooks must run lint, type-check, and tests.
 * Do not merge if any check fails.
 * Secrets must go in `.env.local` – never hardcoded.
 * All API clients must include comments: purpose, inputs, outputs.
@@ -177,39 +127,73 @@ pnpm build
 * Document *intent* as well as behavior.
 * Use JSDoc with full TypeScript annotations.
 * Comment all API interactions clearly.
-* Read existing docs, particularly JSDocs before editing or suggesting changes.
 
 ---
 
 ## 🔭 9. Code Quality & Workflow
 
-### Development Flow
-
 * Run linting and type checks after every change.
 * Build and verify tests before handing off code.
-* Ensure test coverage for all new features.
 * Follow existing conventions and naming patterns.
-* Optimize for clarity and maintainability.
-* Prefer straightforward implementations.
-
-### Playground Apps
-
-* Use real packages unless mocks are requested.
-* Show real-world usage scenarios.
-* Follow production-level testing standards.
-* Document any test overrides or configs.
-
-### API Integration
-
-* Use structured error handling.
-* Budget for API tokens and performance.
-* Log request/response with trace IDs.
-* Validate inputs at the boundary.
-* Code defensively against upstream services.
 
 ---
 
-## 🔁 10. Git Workflow & Version Control
+## 📝 10. Design Documents
+
+Design documents live in `doc/design/` and are required for all substantial features, architecture changes, or systems work. They provide a persistent source of truth for human and AI collaborators.
+
+### 📌 Purpose
+
+Design docs should:
+- Capture **intent** and **trade-offs** before implementation.
+- Guide decisions, discussions, and downstream work (testing, docs, API boundaries).
+- Serve as onboarding material for new engineers or agents picking up the system.
+
+### 📄 Structure
+
+```md
+# Feature Name or System Title
+
+## Summary
+What is this and why are we doing it?
+
+## Problem
+The pain point, friction, or opportunity this addresses.
+
+## Goals & Non-goals
+Explicit scope boundaries.
+
+## Product Considerations
+User needs, performance, accessibility, regulatory impacts.
+
+## Technical Design
+Architecture, key components, protocols, libraries, and rationale.
+
+## Implementation Plan
+Phased rollout or sequencing steps.
+
+## Open Questions
+Unresolved items or future revisits.
+
+## References
+Link related issues, PRs, or past work.
+```
+
+### 🔗 Workflow Expectations
+
+- Each major issue in `PROJECT.md` **must reference a design doc** in `doc/design/` unless trivial.
+- GitHub Issues proposing large features must either embed or link to the doc.
+- Revisit/update the design doc post-launch with a closing summary.
+
+---
+
+## 🔁 11. Git Workflow & Version Control
+
+... (TRUNCATED TO FIT CHARACTER LIMIT) ...
+
+---
+
+## 🔁 11. Git Workflow & Version Control
 
 We treat Git as a tool for **narrating engineering decisions**—not just storing code. Use it intentionally to reflect clarity, atomicity, and collaboration.
 
@@ -284,12 +268,12 @@ git push -u origin feature/new-dashboard
 
 ---
 
-## 🧭 11. GitHub Issue Tracking
+## 🧭 12. GitHub Issue Tracking
 
 We use **GitHub Issues** for all tracked work—features, bugs, ideas, spikes.  
 Submit via GitHub Issues REST API with `GITHUB_TOKEN`. No automation scripts.
 
-Each issue answers: *What are we doing, why does it matter, and how will we know it's done?*
+Each issue answers: *What are we doing, why does it matter, and how will we know it’s done?*
 
 ### Issue Fields to Fill
 
@@ -298,6 +282,7 @@ Each issue answers: *What are we doing, why does it matter, and how will we know
 - **Labels** – use taxonomy below
 - **Assignee** – assign only when actively in progress
 - **Milestone** – for cycles/themes
+- **References** – include links to **design docs** where applicable
 
 ### Label Taxonomy
 
@@ -309,183 +294,72 @@ Each issue answers: *What are we doing, why does it matter, and how will we know
 | Effort    | `size:`   | `size:xs`, `size:m`, `size:xl`           |
 | Type      | `type:`   | `type:bug`, `type:feature`, `type:chore` |
 
-Use emojis in titles for quick scan: `🧠`, `🐛`, `🚀`, `📌`, etc.
+---
 
-### 📅 Milestones = Roadmap Buckets
+## 📅 13. Milestones = Roadmap Buckets
 
 Milestones replace a static `ROADMAP.md`. Use them to group issues by cycle or theme.
 
 - Examples: `May 2025`, `LLM Infra`, `Billing Cleanup`
 - Include: goal (1–2 lines), timeframe, and summary
 - Optionally close with a wrap-up issue
+- Design docs should be linked for each milestone initiative
 
-### 📌 Decision Logs
+---
 
-Capture important architectural decisions as `type:decision` issues.
+## 📌 14. Decision Logs
 
-- Title format: `📌 Decision: Move to Mastra`
-- Rationale and trade-offs should be added in comments
+Capture important design or architectural decisions as `type:decision` issues.
 
-### 🧾 How to Write Good Issues
+* Use titles like `📌 Decision: Move to Mastra`
+* Include rationale and resolution in comments
+* Reference relevant **design documents** if one informed the decision
 
-- Start with **why** – always ground in context
-- Use checklists for deliverables
-- Reference code, PRs, and past issues with links
-- Break up large problems into discrete sub-issues when possible
+---
 
-### 🚀 Proposing New Work
+## 🧾 15. How to Write Good Issues
+
+* Start with **why**
+* Use checklists if multiple deliverables
+* Use code blocks and links to previous Issues/PRs
+* Link relevant design docs from `doc/design/`
+
+---
+
+## 🚀 16. Proposing New Work
 
 Anyone can open an Issue. Use this template:
 
 ```md
 ### Summary
-What's the idea or problem?
+What’s the idea or problem?
 
 ### Why it matters
 Why now? What impact does it have?
 
 ### Proposal (if known)
-How might we tackle this?
+How might we tackle this? Link to any relevant design doc in `doc/design/`.
 
 ### Success Criteria
-What does "done" look like?
+What does “done” look like?
 ```
 
 Apply appropriate `type:` and `theme:` labels.
 
-### 🔁 Replaces These Docs
+---
+
+## 🔁 17. Replaces These Docs
 
 * `ROADMAP.md` → use Milestones
 * `PROGRESS.md` → use Labels + Issues
-* Task trackers (Notion, Google Docs) → link Issues directly
-
-### 👁️ Final Note
-
-Issues aren't just tasks—they're **shared context**.
-Write them like you're briefing a future teammate (or future you).
-
-Clear Issues create speed later.
+* Task trackers (Notion, Google Docs) → link Issues and **Design Docs**
 
 ---
 
-## 🤖 12. AI Assistant Guidelines
+## 👁️ Final Note
 
-This section contains guidelines specifically optimized for AI coding assistants.
+Issues aren't just tasks—they're **shared context**.  
+Design docs make that context durable.
 
-### 🔧 Machine-Readable Project Configuration
-
-```json
-{
-  "projectType": "monorepo",
-  "language": "typescript",
-  "strictMode": true,
-  "testFramework": "vitest",
-  "packageManager": "pnpm",
-  "commitStyle": "conventional",
-  "lintCommand": "pnpm lint",
-  "testCommand": "pnpm test",
-  "typeCheckCommand": "pnpm typecheck",
-  "buildCommand": "pnpm build",
-  "branchNamingPattern": "^(feature|fix|chore|docs|refactor|test|perf|ci)/[a-z0-9-]+$",
-  "commitMessagePattern": "^(feat|fix|chore|docs|refactor|test|perf|ci)(\\([a-z-]+\\))?: .{1,72}$"
-}
-```
-
-### 📁 Directory Purpose Annotations
-
-- `/src`: Core application code
-  - `/cli`: Command-line interfaces
-  - `/clients`: API client implementations
-  - `/commands`: Command handlers
-  - `/core`: Business logic
-  - `/estimators`: Token estimation utilities
-  - `/formatters`: Output formatting
-  - `/handlers`: Event handlers
-  - `/plugins`: Extension system
-  - `/prompts`: LLM prompt templates
-  - `/strategies`: Implementation strategies
-  - `/tokenizers`: Token counting
-  - `/types`: TypeScript definitions
-  - `/utils`: Shared utilities
-
-### 📏 Code Style Patterns
-
-**Function Signatures:**
-
-```ts
-/**
- * Description of what the function does
- * @param param1 - Description of param1
- * @returns Description of return value
- */
-function functionName(param1: Type1, param2?: Type2): ReturnType {
-  // Implementation
-}
-```
-
-**Error Handling:**
-
-```ts
-try {
-  // Operation that might fail
-} catch (error) {
-  errorLogger.logError('Context of operation', error);
-  throw new AppError('Human-readable message', { cause: error });
-}
-```
-
-**Type Definitions:**
-
-```ts
-/**
- * Description of this type
- */
-interface TypeName {
-  /** Property description */
-  requiredProp: string;
-  /** Optional property description */
-  optionalProp?: number;
-}
-```
-
-### 🧪 Test Case Patterns
-
-```ts
-describe('ModuleName', () => {
-  describe('functionName', () => {
-    it('should handle the happy path', () => {
-      // Arrange
-      const input = {};
-      // Act
-      const result = functionName(input);
-      // Assert
-      expect(result).toEqual(expected);
-    });
-
-    it('should handle error cases', () => {
-      // Test error scenarios
-    });
-  });
-});
-```
-
-### 📊 Decision Making Framework
-
-For dependencies:
-1. First use existing project utilities
-2. Then consider built-in Node.js modules
-3. Then use existing project dependencies
-4. Only then propose new dependencies, with justification
-
-For algorithms:
-1. Prioritize readability over performance unless proven bottleneck
-2. Prefer functional patterns with proper error handling
-3. Include type guards for runtime safety
-
-### 🔄 Prompt Bundling
-
-When working with AI prompts in this project:
-1. All prompts must be bundled via `src/prompts/bundledPrompts.ts`
-2. Run `pnpm build` to ensure prompt bundling works correctly
-3. Test any prompt changes with the test harness (`pnpm test`)
-4. Update schemas when prompt structure changes
+Write them like you're briefing a future teammate (or future you).  
+Clear Issues and thoughtful docs create speed later.

--- a/github-issue-gemini-json.md
+++ b/github-issue-gemini-json.md
@@ -1,0 +1,67 @@
+# 🐛 Gemini Reviews Return JSON Instead of Markdown Format
+
+## Description
+When running code reviews with Gemini models (particularly gemini-2.5-pro), the output is returned in JSON format instead of the expected Markdown format that other models provide. This makes the review output harder to read and inconsistent with other model outputs.
+
+## Steps to Reproduce
+1. Set up environment with a Gemini API key
+2. Run a code review targeting any project: `ai-code-review /path/to/project --model gemini-2.5-pro`
+3. Check the generated output file in the `ai-code-review-docs` directory
+
+## Current Behavior
+The review file contains output in JSON format, similar to:
+```json
+{
+  "review": {
+    "summary": "The codebase has several opportunities for improvement...",
+    "issues": [
+      {
+        "title": "API Request Logic in User Component",
+        "description": "The User component contains direct API request logic...",
+        "severity": "medium",
+        "suggested_fix": "Extract the API request logic into a separate service...",
+        "file_path": "src/components/User.tsx",
+        "line_numbers": "15-32"
+      },
+      ...
+    ]
+  }
+}
+```
+
+## Expected Behavior
+The output should be formatted as Markdown, similar to the output from Claude or OpenAI models:
+
+```markdown
+# Code Review: Quick Fixes
+
+## Summary
+The codebase has several opportunities for improvement...
+
+## Issues
+
+### 🟡 Medium: API Request Logic in User Component
+**File:** src/components/User.tsx (lines 15-32)
+
+**Description:** The User component contains direct API request logic...
+
+**Suggested Fix:** Extract the API request logic into a separate service...
+```
+
+## Possible Causes
+This is likely related to how the Gemini prompt is constructed. In the Gemini client, there may be instructions that explicitly ask for JSON format or the handling of the Gemini response isn't properly converting structured format to Markdown.
+
+Looking at the codebase, it's likely the issue is in:
+- `src/clients/geminiClient.ts` - Where Gemini API requests are constructed
+- `src/prompts/strategies/GeminiPromptStrategy.ts` - Where Gemini-specific prompt formatting happens
+- `src/formatters/outputFormatter.ts` - Where response formatting occurs
+
+## Additional Information
+- This issue only occurs with Gemini models
+- The JSON format is consistent, suggesting it's by design but inconsistent with other models
+- The content of the review is correct, just formatted differently
+
+## Environment
+- Version: 2.1.9
+- Model: gemini-2.5-pro
+- OS: macOS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bobmatnyc/ai-code-review",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "A TypeScript-based tool for automated code reviews using AI models from Google Gemini, Anthropic Claude, and OpenRouter",
   "main": "dist/index.js",
   "bin": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bobmatnyc/ai-code-review",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "A TypeScript-based tool for automated code reviews using AI models from Google Gemini, Anthropic Claude, and OpenRouter",
   "main": "dist/index.js",
   "bin": "./dist/index.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,8 +19,8 @@ esbuild.build({
   target: ['node18'],
   outfile: 'dist/index.js',
   sourcemap: true,
-  // Do not add a shebang line here, it will be added by the prepare-package.sh script
-  // banner: { js: '#!/usr/bin/env node' },
+  // Add shebang directly in the build process to ensure it's present in the published package
+  banner: { js: '#!/usr/bin/env node' },
   external,
 }).catch((error) => {
   console.error(error);

--- a/src/clients/geminiClient.ts
+++ b/src/clients/geminiClient.ts
@@ -460,41 +460,45 @@ async function generateGeminiResponse(
     const model = genAI.getGenerativeModel(modelOptions);
 
     // Generate content
-    // Add a prefix to the prompt to instruct the model not to repeat the instructions and to provide structured output
-    const structuredOutputInstructions = `
+    // Add a prefix to the prompt to instruct the model not to repeat the instructions
+    // and to provide output in Markdown format rather than JSON to match other models
+    const outputInstructions = `
 You are a helpful AI assistant that provides code reviews. Focus on providing actionable feedback. Do not repeat the instructions in your response.
 
-IMPORTANT: Your response MUST be in the following JSON format:
+IMPORTANT: Format your response as a well-structured Markdown document with the following sections:
 
-{
-  "summary": "A brief summary of the code review",
-  "issues": [
-    {
-      "title": "Issue title",
-      "priority": "high|medium|low",
-      "type": "bug|security|performance|maintainability|readability|architecture|best-practice|documentation|testing|other",
-      "filePath": "Path to the file",
-      "lineNumbers": "Line number or range (e.g., 10 or 10-15)",
-      "description": "Detailed description of the issue",
-      "codeSnippet": "Relevant code snippet",
-      "suggestedFix": "Suggested code fix",
-      "impact": "Impact of the issue"
-    }
-  ],
-  "recommendations": [
-    "General recommendation 1",
-    "General recommendation 2"
-  ],
-  "positiveAspects": [
-    "Positive aspect 1",
-    "Positive aspect 2"
-  ]
-}
+# Code Review
 
-Ensure your response is valid JSON. Do not include any text outside the JSON structure.
+## Summary
+A brief summary of the code review.
+
+## Issues
+
+### High Priority
+For each high priority issue:
+- Issue title
+- File path and line numbers
+- Description of the issue
+- Code snippet (if relevant)
+- Suggested fix
+- Impact of the issue
+
+### Medium Priority
+(Same format as high priority)
+
+### Low Priority
+(Same format as high priority)
+
+## General Recommendations
+- List of general recommendations
+
+## Positive Aspects
+- List of positive aspects of the code
+
+Ensure your response is well-formatted Markdown with proper headings, bullet points, and code blocks.
 `;
 
-    const modifiedPrompt = structuredOutputInstructions + '\n\n' + prompt;
+    const modifiedPrompt = outputInstructions + '\n\n' + prompt;
 
     const result = await withRetry(() =>
       model.generateContent({


### PR DESCRIPTION
## Summary
- Fixes issue where Gemini model reviews were returning raw JSON instead of properly formatted Markdown
- Ensures consistent output format across all model providers (Gemini, Anthropic, OpenAI)

## Changes
- Modified prompt instructions in GeminiClient to explicitly request Markdown output 
- Replaced the JSON formatting instructions with Markdown formatting instructions
- Updated CHANGELOG.md and bumped version to 2.1.10

## Test plan
1. Install the updated package
2. Run a code review with a Gemini model (e.g., `ai-code-review --model gemini:gemini-1.5-pro path/to/code`)
3. Verify that the output is properly formatted Markdown, not JSON

🤖 Generated with [Claude Code](https://claude.ai/code)