### PR TITLE
feat: add OpenAI o3 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,10 @@ Alternatively, you can manually place your `.env.local` file in one of these loc
 # Specify which model to use for code reviews using the format provider:model
 # The tool will automatically map this to the correct API model name
 AI_CODE_REVIEW_MODEL=gemini:gemini-1.5-pro
+# or
+# AI_CODE_REVIEW_MODEL=openai:o3
+# or
+# AI_CODE_REVIEW_MODEL=openai:o3-mini
 
 # See the Supported Models section for all available models and their API mappings
 
@@ -757,6 +761,8 @@ You can see all available models and their mappings by running `ai-code-review -
 | `openai:gpt-4-turbo` | Powerful model with good code analysis | `AI_CODE_REVIEW_OPENAI_API_KEY` | `gpt-4-turbo-preview` |
 | `openai:gpt-4o` | OpenAI's latest model with strong code understanding | `AI_CODE_REVIEW_OPENAI_API_KEY` | `gpt-4o` |
 | `openai:gpt-4` | Original GPT-4 model | `AI_CODE_REVIEW_OPENAI_API_KEY` | `gpt-4` |
+| `openai:o3` | OpenAI's latest advanced reasoning model | `AI_CODE_REVIEW_OPENAI_API_KEY` | `o3` |
+| `openai:o3-mini` | Smaller, more efficient version of o3 | `AI_CODE_REVIEW_OPENAI_API_KEY` | `o3-mini` |
 
 ### Extending the Model Mapping System
 

--- a/src/__tests__/modelMaps.test.ts
+++ b/src/__tests__/modelMaps.test.ts
@@ -104,7 +104,7 @@ describe('modelMaps', () => {
       );
 
       // Verify we have the expected number of OpenAI models
-      expect(openaiModels.length).toBe(5);
+      expect(openaiModels.length).toBe(7);
 
       // Verify specific model keys exist
       expect(openaiModels).toContain('openai:gpt-4.1');
@@ -112,6 +112,8 @@ describe('modelMaps', () => {
       expect(openaiModels).toContain('openai:gpt-4-turbo');
       expect(openaiModels).toContain('openai:gpt-3.5-turbo');
       expect(openaiModels).toContain('openai:gpt-4.5');
+      expect(openaiModels).toContain('openai:o3');
+      expect(openaiModels).toContain('openai:o3-mini');
 
       // Verify properties of a specific model
       const gpt4o = MODEL_MAP['openai:gpt-4o'];
@@ -119,6 +121,22 @@ describe('modelMaps', () => {
       expect(gpt4o.displayName).toBe('GPT-4o');
       expect(gpt4o.contextWindow).toBe(128000);
       expect(gpt4o.apiKeyEnvVar).toBe('AI_CODE_REVIEW_OPENAI_API_KEY');
+
+      // Verify o3 model properties
+      const o3 = MODEL_MAP['openai:o3'];
+      expect(o3.apiIdentifier).toBe('o3');
+      expect(o3.displayName).toBe('OpenAI o3');
+      expect(o3.contextWindow).toBe(200000);
+      expect(o3.apiKeyEnvVar).toBe('AI_CODE_REVIEW_OPENAI_API_KEY');
+      expect(o3.supportsToolCalling).toBe(true);
+
+      // Verify o3-mini model properties
+      const o3Mini = MODEL_MAP['openai:o3-mini'];
+      expect(o3Mini.apiIdentifier).toBe('o3-mini');
+      expect(o3Mini.displayName).toBe('OpenAI o3-mini');
+      expect(o3Mini.contextWindow).toBe(200000);
+      expect(o3Mini.apiKeyEnvVar).toBe('AI_CODE_REVIEW_OPENAI_API_KEY');
+      expect(o3Mini.supportsToolCalling).toBe(true);
     });
   });
 
@@ -168,8 +186,10 @@ describe('modelMaps', () => {
       expect(MODELS.anthropic).toContain('anthropic:claude-3.7-sonnet');
 
       // Check OpenAI models
-      expect(MODELS.openai.length).toBe(5);
+      expect(MODELS.openai.length).toBe(7);
       expect(MODELS.openai).toContain('openai:gpt-4o');
+      expect(MODELS.openai).toContain('openai:o3');
+      expect(MODELS.openai).toContain('openai:o3-mini');
 
       // Check OpenRouter models
       expect(MODELS.openrouter.length).toBe(5);

--- a/src/clients/utils/modelMaps.ts
+++ b/src/clients/utils/modelMaps.ts
@@ -156,6 +156,24 @@ export const MODEL_MAP: Record<string, ModelMapping> = {
     "apiKeyEnvVar": "AI_CODE_REVIEW_OPENAI_API_KEY",
     "supportsToolCalling": false
   },
+  "openai:o3": {
+    "apiIdentifier": "o3",
+    "displayName": "OpenAI o3",
+    "provider": "openai",
+    "contextWindow": 200000,
+    "description": "OpenAI's latest advanced reasoning model",
+    "apiKeyEnvVar": "AI_CODE_REVIEW_OPENAI_API_KEY",
+    "supportsToolCalling": true
+  },
+  "openai:o3-mini": {
+    "apiIdentifier": "o3-mini",
+    "displayName": "OpenAI o3-mini",
+    "provider": "openai",
+    "contextWindow": 200000,
+    "description": "Smaller, more efficient version of o3",
+    "apiKeyEnvVar": "AI_CODE_REVIEW_OPENAI_API_KEY",
+    "supportsToolCalling": true
+  },
   "openrouter:anthropic/claude-3-opus": {
     "apiIdentifier": "anthropic/claude-3-opus-20240229",
     "displayName": "Claude 3 Opus (via OpenRouter)",

--- a/src/estimators/openaiEstimator.ts
+++ b/src/estimators/openaiEstimator.ts
@@ -67,6 +67,16 @@ export class OpenAITokenEstimator extends AbstractTokenEstimator {
       outputTokenCost: 0.002 // $2.00 per 1M tokens
     },
 
+    // o3 models (Note: Pricing is estimated based on expected advanced capabilities)
+    'o3': {
+      inputTokenCost: 0.015, // $15.00 per 1M tokens (estimated)
+      outputTokenCost: 0.060 // $60.00 per 1M tokens (estimated)
+    },
+    'o3-mini': {
+      inputTokenCost: 0.0015, // $1.50 per 1M tokens (estimated)
+      outputTokenCost: 0.006 // $6.00 per 1M tokens (estimated)
+    },
+
     // Default fallback pricing (using GPT-4o as default)
     default: {
       inputTokenCost: 0.005, // $5.00 per 1M tokens
@@ -125,6 +135,6 @@ export class OpenAITokenEstimator extends AbstractTokenEstimator {
    * @returns True if the model is supported, false otherwise
    */
   supportsModel(modelName: string): boolean {
-    return modelName in this.MODEL_PRICING || modelName.startsWith('gpt-');
+    return modelName in this.MODEL_PRICING || modelName.startsWith('gpt-') || modelName.startsWith('o3');
   }
 }


### PR DESCRIPTION
## Summary
- Added support for OpenAI's o3 and o3-mini models
- Integrated o3 models into the existing OpenAI client infrastructure

## Test plan
- [x] Added model configuration entries in modelMaps.ts
- [x] Updated OpenAI estimator with pricing information
- [x] Added comprehensive test coverage for o3 models
- [x] Updated documentation with usage examples
- [x] All tests passing (`npm test -- modelMaps.test.ts`)
- [x] Linting passes (`npm run lint`)
- [x] Type checking passes (`npm run build:types`)

## Details
This PR adds support for OpenAI's latest o3 reasoning models:
- **o3**: Advanced reasoning model with 200k context window
- **o3-mini**: Smaller, more efficient version of o3

### Changes made:
1. Added o3 model configurations to `modelMaps.ts` with tool calling support enabled
2. Updated `openaiEstimator.ts` with estimated pricing for o3 models
3. Added test coverage for both o3 models in the test suite
4. Updated README.md with o3 model documentation and usage examples
5. Modified the `supportsModel` method to recognize o3 model names

### Usage example:
```bash
# Set in .env.local
AI_CODE_REVIEW_MODEL=openai:o3
# or
AI_CODE_REVIEW_MODEL=openai:o3-mini

# Run code review
ai-code-review src --type architectural
```

Closes #33

🤖 Generated with [Claude Code](https://claude.ai/code)