### PR TITLE
feat: improve error messages for incorrect command parameters

### DIFF
--- a/src/__tests__/core/fileDiscovery.test.ts
+++ b/src/__tests__/core/fileDiscovery.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview Tests for file discovery parameter validation
+ */
+
+import { discoverFiles } from '../../core/fileDiscovery';
+import * as fileSystem from '../../utils/fileSystem';
+import * as fileFilters from '../../utils/fileFilters';
+import * as smartFileSelector from '../../utils/files/smartFileSelector';
+
+// Mock the dependencies
+jest.mock('../../utils/fileSystem');
+jest.mock('../../utils/fileFilters');
+jest.mock('../../utils/files/smartFileSelector');
+jest.mock('../../utils/logger', () => {
+  const mockLogger = {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  };
+  return {
+    __esModule: true,
+    default: mockLogger
+  };
+});
+
+describe('fileDiscovery parameter validation', () => {
+  const mockProjectPath = '/test/project';
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Set up default mocks
+    (fileSystem.pathExists as jest.Mock).mockResolvedValue(true);
+    (fileSystem.isDirectory as jest.Mock).mockResolvedValue(false);
+    (fileSystem.isPathWithinCwd as jest.Mock).mockReturnValue(true);
+    (fileFilters.loadGitignorePatterns as jest.Mock).mockResolvedValue([]);
+    (fileFilters.getFilesToReview as jest.Mock).mockResolvedValue(['test.ts']);
+    (smartFileSelector.applySmartFiltering as jest.Mock).mockResolvedValue(['test.ts']);
+  });
+  
+  describe('validateTargetParameter', () => {
+    it('should throw error for parameter with = format', async () => {
+      await expect(discoverFiles('type=performance', mockProjectPath))
+        .rejects.toThrow(/Invalid parameter format: 'type=performance'/);
+    });
+    
+    it('should provide helpful suggestion for known options with =', async () => {
+      await expect(discoverFiles('type=performance', mockProjectPath))
+        .rejects.toThrow(/Did you mean: --type performance/);
+    });
+    
+    it('should provide examples in error message', async () => {
+      await expect(discoverFiles('type=performance', mockProjectPath))
+        .rejects.toThrow(/Example usage:/);
+    });
+    
+    it('should handle unknown parameters with =', async () => {
+      await expect(discoverFiles('foo=bar', mockProjectPath))
+        .rejects.toThrow(/Parameters should use '--' prefix, not '=' format/);
+    });
+    
+    it('should throw error for options without -- prefix', async () => {
+      await expect(discoverFiles('type', mockProjectPath))
+        .rejects.toThrow(/'type' looks like an option but is missing '--' prefix/);
+    });
+    
+    it('should provide suggestion for missing -- prefix', async () => {
+      await expect(discoverFiles('debug', mockProjectPath))
+        .rejects.toThrow(/Did you mean: --debug/);
+    });
+    
+    it('should handle single dash options', async () => {
+      await expect(discoverFiles('-type', mockProjectPath))
+        .rejects.toThrow(/Options should use double dashes/);
+    });
+    
+    it('should not throw error for valid file paths', async () => {
+      // Should not throw validation error for valid paths
+      await expect(discoverFiles('src/index.ts', mockProjectPath))
+        .resolves.toEqual(['test.ts']);
+    });
+    
+    it('should not throw error for paths with equals in them', async () => {
+      // File paths that legitimately contain = should be allowed
+      await expect(discoverFiles('src/file=name.ts', mockProjectPath))
+        .resolves.toEqual(['test.ts']);
+    });
+    
+    it('should handle multiple equals signs correctly', async () => {
+      const error = await discoverFiles('type=performance=high', mockProjectPath)
+        .catch(e => e);
+      expect(error.message).toContain("Did you mean: --type performance=high");
+    });
+  });
+  
+  describe('error message quality', () => {
+    it('should include help command suggestion', async () => {
+      await expect(discoverFiles('type=performance', mockProjectPath))
+        .rejects.toThrow(/Run 'ai-code-review --help' for more options/);
+    });
+    
+    it('should show common usage patterns', async () => {
+      await expect(discoverFiles('foo=bar', mockProjectPath))
+        .rejects.toThrow(/Common usage patterns:/);
+    });
+    
+    it('should show example for specific option', async () => {
+      const error = await discoverFiles('output=json', mockProjectPath)
+        .catch(e => e);
+      expect(error.message).toContain('ai-code-review --output json');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added friendly, helpful error messages when users provide incorrectly formatted command parameters
- Validates target parameter to detect common mistakes before file discovery

## Test plan
- [x] Added parameter validation function in fileDiscovery.ts
- [x] Created comprehensive unit tests for all validation scenarios
- [x] All tests passing (236 tests total)
- [x] Manually tested various incorrect parameter formats
- [x] Build successful

## Details
This PR implements the improvements outlined in issue #35 to provide better error messages when users make common mistakes with command syntax.

### Before:
```
ai-code-review type=performance
[ERROR] Target not found: type=performance
[ERROR] This appears to be a file access or processing issue.
```

### After:
```
ai-code-review type=performance
[ERROR] Invalid parameter format: 'type=performance'
    
It looks like you're trying to set the 'type' option.
Did you mean: --type performance

Example usage:
  ai-code-review --type performance
  ai-code-review src --type performance
  ai-code-review . --type performance

Run 'ai-code-review --help' for more options.
```

### Implementation:
1. Added `validateTargetParameter` function that checks for:
   - Parameters using `=` format (e.g., `type=performance`)
   - Options missing `--` prefix (e.g., `debug` instead of `--debug`)
   - Smart detection to avoid false positives for legitimate file paths

2. Provides helpful suggestions including:
   - Correct syntax for the detected option
   - Multiple usage examples
   - Reference to help command

3. Added comprehensive test coverage for all scenarios

Closes #35

🤖 Generated with [Claude Code](https://claude.ai/code)