### PR TITLE
Fix review output formatting - exclude ciData from commandOptions (fixes #46)

### DIFF
--- a/.github/ISSUE_TEMPLATE/review-formatting-issue.md
+++ b/.github/ISSUE_TEMPLATE/review-formatting-issue.md
@@ -1,0 +1,83 @@
+---
+name: Review Output Formatting Issues
+about: Fix formatting issues in review output files
+title: 'Fix review output formatting issues - remove inline ciData JSON and improve metadata display'
+labels: 'bug, enhancement, formatting'
+assignees: ''
+
+---
+
+## Problem Description
+
+The review output files have formatting issues that make them difficult to read:
+
+1. **Inline ciData JSON**: The entire ciData JSON (containing all TypeScript errors for every file) is being displayed inline in the command options, making the metadata section extremely verbose and hard to read.
+
+2. **Command Options Display**: The command options in the metadata section include internal data structures that shouldn't be displayed to users.
+
+## Example of Current Issue
+
+In file: `ai-code-review-docs/quick-fixes-review-current-dir-gemini-gemini-2-5-pro-2025-06-03T22-45-16-778Z.md`
+
+```
+| Command Options | `--type=quick-fixes --output=markdown --model=gemini:gemini-2.5-pro --includeProjectDocs --contextMaintenanceFactor=0.15 --language=typescript --framework=none --ciData='{"typeCheckErrors":47,"lintErrors":0,"typeCheckOutput":"...HUNDREDS OF LINES OF JSON..."}' |
+```
+
+## Expected Behavior
+
+The command options should only display user-provided CLI options, not internal data structures:
+
+```
+| Command Options | `--type=quick-fixes --output=markdown --model=gemini:gemini-2.5-pro --includeProjectDocs --contextMaintenanceFactor=0.15 --language=typescript --framework=none` |
+```
+
+## Root Cause
+
+1. The `ConsolidatedReviewStrategy` adds the entire ciData object to the options: `options.ciData = ciData`
+2. The `ReviewGenerator` serializes ALL options (including internal ones) into the commandOptions string
+
+## Proposed Solution
+
+1. **Filter out internal options**: Modify `ReviewGenerator.ts` to exclude internal options like `ciData` from the commandOptions serialization
+2. **Add type safety**: Update the `ReviewOptions` interface to properly type the ciData property
+3. **Consider alternative approaches**: 
+   - Store ciData separately in the review metadata
+   - Only include a summary of CI data (e.g., error counts) instead of full details
+
+## Implementation Details
+
+### Files to Modify
+
+1. `src/core/ReviewGenerator.ts` - Add filter to exclude internal options
+2. `src/types/review.ts` - Add ciData property to ReviewOptions interface
+3. `src/strategies/ConsolidatedReviewStrategy.ts` - Document the ciData addition
+
+### Code Changes
+
+Already implemented in commit [commit-hash]:
+
+```typescript
+// ReviewGenerator.ts
+.filter(([key, value]) => {
+  // Filter out internal options and undefined values
+  if (key.startsWith('_') || value === undefined) return false;
+  
+  // Filter out ciData which can be very large
+  if (key === 'ciData') return false;
+  
+  // ... rest of filters
+})
+```
+
+## Testing
+
+1. Run a review with TypeScript errors present
+2. Verify the output file's metadata section doesn't contain inline ciData JSON
+3. Verify all user-provided options are still displayed correctly
+4. Check that CI data is still available to the review process (just not displayed)
+
+## Additional Considerations
+
+- Should we display a summary of CI data (e.g., "47 TypeScript errors, 0 lint errors") in the metadata?
+- Should other internal options be filtered out?
+- Consider creating a separate "Internal Metadata" section for debugging purposes

--- a/src/core/ReviewGenerator.ts
+++ b/src/core/ReviewGenerator.ts
@@ -128,6 +128,9 @@ export async function generateReview(
       // Filter out internal options and undefined values
       if (key.startsWith('_') || value === undefined) return false;
       
+      // Filter out ciData which can be very large
+      if (key === 'ciData') return false;
+      
       // Filter out empty arrays and objects
       if (Array.isArray(value) && value.length === 0) return false;
       if (typeof value === 'object' && value !== null && Object.keys(value).length === 0) return false;

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -65,6 +65,8 @@ export interface ReviewOptions {
   listmodels?: boolean;
   /** Whether to list all supported models and their configuration names */
   models?: boolean;
+  /** CI/CD data (TypeScript errors, lint errors) - internal use only */
+  ciData?: any;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes the review output formatting issue where the entire ciData JSON was being displayed inline in the command options metadata section.

## Problem

When running reviews on TypeScript projects, the ConsolidatedReviewStrategy collects CI data (TypeScript errors, lint errors) and adds it to the options object. The ReviewGenerator then serializes ALL options into a commandOptions string for display in the review metadata. This resulted in hundreds of lines of JSON being displayed inline, making the review files difficult to read.

## Solution

- Added a filter in ReviewGenerator.ts to exclude the `ciData` property from commandOptions serialization
- Added the `ciData` property to the ReviewOptions interface for proper typing
- The CI data is still available to the review process, just not displayed in the metadata

## Changes

1. **src/core/ReviewGenerator.ts**: Added filter to exclude ciData from commandOptions
2. **src/types/review.ts**: Added ciData property to ReviewOptions interface  
3. **.github/ISSUE_TEMPLATE/review-formatting-issue.md**: Added issue template for documentation

## Testing

- [x] Built project successfully with `npm run build`
- [x] Linter passes (existing warnings unrelated to these changes)
- [x] Verified ciData is excluded from commandOptions string
- [ ] Manual testing: Run a review and verify output formatting

## Example

**Before:**
```
| Command Options | `--type=quick-fixes --output=markdown --ciData='{"typeCheckErrors":47,"lintErrors":0,"typeCheckOutput":"...HUNDREDS OF LINES..."}'` |
```

**After:**
```
| Command Options | `--type=quick-fixes --output=markdown` |
```

Fixes #46