### PR TITLE
Fix: respect --skip-key-check flag on startup

### DIFF
--- a/src/cli/argumentParser.ts
+++ b/src/cli/argumentParser.ts
@@ -620,6 +620,7 @@ interface ParsedArguments {
   enableSemanticChunking?: boolean;
   interactive?: boolean;
   testApi?: boolean;
+  skipKeyCheck?: boolean;
   estimate?: boolean;
   multiPass?: boolean;
   forceSinglePass?: boolean;
@@ -775,6 +776,7 @@ export function mapArgsToReviewOptions(
     typescriptVersion: argv.typescriptVersion,
     memoryLimit: argv.memoryLimit,
     executionTimeout: argv.executionTimeout,
+    skipKeyCheck: argv.skipKeyCheck,
 
     // AI Detection options
     enableAiDetection: argv.enableAiDetection,


### PR DESCRIPTION
## Summary

This PR fixes the \`--skip-key-check\` flag not being respected during startup validation.

Fixes #91

## Changes

- Ensures \`skipKeyCheck\` parsed from CLI arguments in \`argumentParser.ts\` is properly wired through so that API key validation is bypassed when the flag is set

## Testing

- Pass \`--skip-key-check\` on startup and confirm the process no longer exits on missing API keys