### PR TITLE
Fix: respect AI_CODE_REVIEW_GOOGLE_API_ENDPOINT in Gemini client and health check

### DIFF
--- a/src/clients/implementations/geminiClient.ts
+++ b/src/clients/implementations/geminiClient.ts
@@ -139,6 +139,12 @@ export class GeminiClient extends AbstractClient {
 
       logger.info(`Initializing Gemini model: ${this.modelName} (API: ${apiModelName})...`);
 
+      // Check for custom API endpoint override
+      const customEndpoint = process.env.AI_CODE_REVIEW_GOOGLE_API_ENDPOINT;
+      if (customEndpoint) {
+        logger.info(`Using custom Gemini API endpoint: ${customEndpoint}`);
+      }
+
       // Initialize the Google Generative AI client
       this.genAI = new GoogleGenerativeAI(this.apiKey || '');
 
@@ -567,10 +573,14 @@ Ensure your response is well-formatted Markdown with proper headings, bullet poi
     try {
       // Create model instance
       // Note: API versioning is handled internally by the SDK based on model name
-      const model = this.genAI.getGenerativeModel({
-        model: this.customModel.name,
-        safetySettings: DEFAULT_SAFETY_SETTINGS,
-      });
+      const customEndpoint = process.env.AI_CODE_REVIEW_GOOGLE_API_ENDPOINT;
+      const model = this.genAI.getGenerativeModel(
+        {
+          model: this.customModel.name,
+          safetySettings: DEFAULT_SAFETY_SETTINGS,
+        },
+        customEndpoint ? { baseUrl: customEndpoint } : undefined,
+      );
 
       // Determine mode and build prompt
       const isInteractiveMode = options?.interactive === true;

--- a/src/utils/apiKeyHealthCheck.ts
+++ b/src/utils/apiKeyHealthCheck.ts
@@ -26,7 +26,11 @@ export interface KeyValidationResult {
  */
 async function validateGoogleApiKey(apiKey: string): Promise<KeyValidationResult> {
   try {
-    const url = `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`;
+    const customEndpoint =
+      process.env.AI_CODE_REVIEW_GOOGLE_API_ENDPOINT ||
+      'https://generativelanguage.googleapis.com';
+    const baseUrl = customEndpoint.replace(/\/$/, '');
+    const url = `${baseUrl}/v1beta/models?key=${apiKey}`;
     const response = await fetch(url, {
       method: 'GET',
       headers: {


### PR DESCRIPTION
## Summary

Fixes #93

The \`AI_CODE_REVIEW_GOOGLE_API_ENDPOINT\` environment variable was silently ignored in two places, causing all Gemini API calls and key validation to always hit the default Google endpoint.

## Changes

### \`src/clients/implementations/geminiClient.ts\`
- Reads \`AI_CODE_REVIEW_GOOGLE_API_ENDPOINT\` at model initialization and logs when a custom endpoint is active
- Passes \`{ baseUrl: customEndpoint }\` as the second argument to \`getGenerativeModel()\` so the SDK routes all requests through the configured endpoint

### \`src/utils/apiKeyHealthCheck.ts\`
- Updates \`validateGoogleApiKey()\` to build the validation URL from \`AI_CODE_REVIEW_GOOGLE_API_ENDPOINT\`, falling back to \`https://generativelanguage.googleapis.com\` if not set
- Strips any trailing slash from the custom endpoint before constructing the URL

## Testing

Set \`AI_CODE_REVIEW_GOOGLE_API_ENDPOINT\` to a custom URL and confirm both health check and review calls are routed correctly.