### PR TITLE
feat: add --stdout option to CLI

### DIFF
--- a/src/cli/argumentParser.ts
+++ b/src/cli/argumentParser.ts
@@ -422,6 +422,11 @@ export function parseArguments(): any {
               type: 'boolean',
               default: false,
             })
+            .option('stdout', {
+              describe: 'Emit output to stdout instead of saving to a file',
+            type: 'boolean',
+            default: false,
+            })
         );
       },
     )
@@ -619,6 +624,7 @@ interface ParsedArguments {
   includeDependencyAnalysis?: boolean;
   enableSemanticChunking?: boolean;
   interactive?: boolean;
+  stdout?: boolean;
   testApi?: boolean;
   estimate?: boolean;
   multiPass?: boolean;
@@ -702,6 +708,7 @@ export function mapArgsToReviewOptions(
     includeDependencyAnalysis: argv.includeDependencyAnalysis,
     enableSemanticChunking: argv.enableSemanticChunking,
     interactive: argv.interactive,
+    stdout: argv.stdout,
     testApi: argv.testApi,
     estimate: argv.estimate,
     multiPass: argv.multiPass,

--- a/src/core/OutputManager.ts
+++ b/src/core/OutputManager.ts
@@ -362,10 +362,14 @@ export async function saveReviewOutput(
       extension,
     );
 
-    // Write the formatted output to the file
-    logger.debug(`Writing formatted review output to: ${outputPath}`);
-    await fs.writeFile(outputPath, formattedOutput);
-    logger.info(`Review output saved to: ${outputPath}`);
+    if (options.stdout) {
+      process.stdout.write(`${formattedOutput}\n`);
+    } else {
+      // Write the formatted output to the file
+      logger.debug(`Writing formatted review output to: ${outputPath}`);
+      await fs.writeFile(outputPath, formattedOutput);
+      logger.info(`Review output saved to: ${outputPath}`);
+    }
 
     // Process optional outputs (diagrams, raw data, removal scripts)
     await processOptionalOutputs(
@@ -377,7 +381,7 @@ export async function saveReviewOutput(
       outputBaseDir,
     );
 
-    return outputPath;
+    return options.stdout ? 'stdout' : outputPath;
   } catch (error: unknown) {
     await handleSaveError(error, options);
     throw error;

--- a/src/core/OutputManager.ts
+++ b/src/core/OutputManager.ts
@@ -8,7 +8,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { formatReviewOutput } from '../formatters/outputFormatter';
-import type { FileInfo, ReviewOptions, ReviewResult } from '../types/review';
+import type { FileInfo, ReviewOptions, ReviewResult, SaveReviewOutputResult } from '../types/review';
 import { createAIDependencyAnalysis } from '../utils/dependencies/aiDependencyAnalyzer';
 import { processDiagrams } from '../utils/diagramGenerator';
 import { logError } from '../utils/errorLogger';
@@ -320,7 +320,7 @@ export async function saveReviewOutput(
   modelName: string,
   targetName: string,
   files?: FileInfo[],
-): Promise<string> {
+): Promise<SaveReviewOutputResult> {
   try {
     const extension = options.output === 'json' ? '.json' : '.md';
     const { outputPath: initialPath, rawDataPath } = await generateOutputPaths(
@@ -381,7 +381,10 @@ export async function saveReviewOutput(
       outputBaseDir,
     );
 
-    return options.stdout ? 'stdout' : outputPath;
+    return {
+      path: options.stdout ? null : outputPath,
+      destination: options.stdout ? 'stdout' : 'file',
+    };
   } catch (error: unknown) {
     await handleSaveError(error, options);
     throw error;

--- a/src/core/handlers/OutputHandler.ts
+++ b/src/core/handlers/OutputHandler.ts
@@ -37,7 +37,7 @@ export async function handleReviewOutput(
       const targetName = path.basename(options.target || '.');
       const modelName = options.model || 'unknown-model';
 
-      const outputPath = await saveReviewOutput(
+      const { path: outputPath, destination } = await saveReviewOutput(
         reviewResult,
         options,
         outputBaseDir,
@@ -45,12 +45,12 @@ export async function handleReviewOutput(
         targetName,
       );
 
-      if (outputPath !== 'stdout') {
+      if (destination !== 'stdout') {
         logger.info(`Review saved to: ${outputPath}`);
       }
 
       // Display review interactively if requested
-      if (options.interactive) {
+      if (options.interactive && outputPath) {
         try {
           await displayReviewInteractively(outputPath, process.cwd(), options);
         } catch (error) {

--- a/src/core/handlers/OutputHandler.ts
+++ b/src/core/handlers/OutputHandler.ts
@@ -45,7 +45,9 @@ export async function handleReviewOutput(
         targetName,
       );
 
-      logger.info(`Review saved to: ${outputPath}`);
+      if (outputPath !== 'stdout') {
+        logger.info(`Review saved to: ${outputPath}`);
+      }
 
       // Display review interactively if requested
       if (options.interactive) {

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -53,6 +53,8 @@ export interface ReviewOptions {
   includeDependencyAnalysis?: boolean;
   /** Whether to enable semantic chunking for intelligent code analysis */
   enableSemanticChunking?: boolean;
+  /** Whether to emit output to stdout instead of saving to a file */
+  stdout?: boolean;
   /** Whether to run in interactive mode */
   interactive?: boolean;
   /** Whether to test API connections before running the review */

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -31,6 +31,13 @@ export type ReviewType =
   | 'developer-experience'
   | 'comprehensive';
 
+export type OutputDestination = 'file' | 'stdout';
+
+export interface SaveReviewOutputResult {
+  path: string | null;
+  destination: OutputDestination;
+}
+
 /**
  * Options for code reviews
  */


### PR DESCRIPTION
This PR adds the `--stdout` option to the CLI to support emitting the code review output directly to stdout.

It updates the argument parser and output manager to redirect the formatted markdown or JSON directly to standard output when the flag is present, making it easier for agents and automated workflows to consume the output.

Fixes #96